### PR TITLE
Update Project Dependencies

### DIFF
--- a/athenz.go
+++ b/athenz.go
@@ -162,7 +162,7 @@ func GetRoleToken(
 	client := zts.NewClient(url, nil)
 	client.AddCredentials(authHeader, ntoken)
 	roleToken, err = client.GetRoleToken(
-		zts.DomainName(providerDomain), zts.EntityName(role),
+		zts.DomainName(providerDomain), zts.EntityList(role),
 		&defaultRoleTokenMinExpiryTime, &defaultRoleTokenMaxExpiryTime, "",
 	)
 	if err != nil {

--- a/athenz.go
+++ b/athenz.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/yahoo/athenz/clients/go/zts"
 	"github.com/yahoo/athenz/libs/go/zmssvctoken"
 )

--- a/cli/pulsar-client/pulsar-client.go
+++ b/cli/pulsar-client/pulsar-client.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
 	flags "github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	pulsar "github.com/t2y/go-pulsar"
 	"github.com/t2y/go-pulsar/internal/parse"

--- a/cli/pulsar-client/pulsar-client.go
+++ b/cli/pulsar-client/pulsar-client.go
@@ -208,7 +208,7 @@ func runProduceCommand(opts *pulsar.Options, client *pulsar.PulsarClient) {
 	)
 
 	producer := pulsar.NewProducer(client)
-	if err := producer.CreateProcuder(opts.Topic, producerId, requestId); err != nil {
+	if err := producer.CreateProducer(opts.Topic, producerId, requestId); err != nil {
 		log.WithFields(log.Fields{
 			"err": err,
 		}).Fatal("Failed to send producer")

--- a/client.go
+++ b/client.go
@@ -5,9 +5,9 @@ import (
 	"net/url"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	pulsar_proto "github.com/t2y/go-pulsar/proto/pb"
 )

--- a/config.go
+++ b/config.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/ini.v1"
 
 	"github.com/t2y/go-pulsar/internal/parse"

--- a/connection.go
+++ b/connection.go
@@ -12,9 +12,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	command "github.com/t2y/go-pulsar/proto/command"
 	pulsar_proto "github.com/t2y/go-pulsar/proto/pb"

--- a/consumer.go
+++ b/consumer.go
@@ -1,9 +1,9 @@
 package pulsar
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	pulsar_proto "github.com/t2y/go-pulsar/proto/pb"
 )

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: b07e1f39655e304f454e283636873542a6a9dfbff317de66c702c29a33dafb66
-updated: 2018-03-08T15:17:40.369449-05:00
+hash: 0dfeca20baf4e873b1f48400ff213ac7ca274ebcf9ba1a709c2d58cfad6fb4ca
+updated: 2018-03-08T15:33:17.390292-05:00
 imports:
 - name: github.com/ardielle/ardielle-go
-  version: 7d2a39380f7e6beef97bc5462144d6cf902a7ff3
+  version: eceec2d93a832e111f4e0f7dd58adcf95a616038
   subpackages:
   - rdl
 - name: github.com/golang/protobuf
-  version: 0a4f71a498b7c4812f64969510bcb4eca251e33a
+  version: bbd03ef6da3a115852eaf24c8a1c46aeb39aa175
   subpackages:
   - proto
   - proto/testdata
@@ -20,13 +20,13 @@ imports:
   - ptypes/timestamp
   - ptypes/wrappers
 - name: github.com/jessevdk/go-flags
-  version: 5695738f733662da3e9afc2283bba6f3c879002d
+  version: f88afde2fa19a30cf50ba4b05b3d13bc6bae3079
 - name: github.com/pkg/errors
-  version: c605e284fe17294bda444b34710735b29d1a9d90
+  version: 30136e27e2ac8d167177e8a583aa4c3fea5be833
 - name: github.com/sirupsen/logrus
   version: f4ee69125072b22721efbe639bd0da9c9d19b8cc
 - name: github.com/yahoo/athenz
-  version: cc53e4123d013b18cfe3540d98bc3cb73c2adfe2
+  version: 8f77959f35d146f2042d4feca72b82c165e351e7
   subpackages:
   - clients/go/zts
   - libs/go/zmssvctoken
@@ -35,14 +35,14 @@ imports:
   subpackages:
   - ssh/terminal
 - name: golang.org/x/sys
-  version: abf9c25f54453410d0c6668e519582a9e1115027
+  version: 7dca6fe1f43775aa6d1334576870ff63f978f539
   subpackages:
   - unix
   - windows
 - name: gopkg.in/ini.v1
-  version: d3de07a94d22b4a0972deb4b96d790c2c0ce8333
+  version: 6333e38ac20b8949a8dd68baa3650f4dee8f39f0
 testImports:
 - name: golang.org/x/sync
-  version: f52d1811a62927559de87708c8913c1650ce4f26
+  version: fd80eb99c8f653c847d294a001bdf2a3a6f768f5
   subpackages:
   - errgroup

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8ed0770421c781e49c2247bfe44c9459dca949d1626d0513b75845185bcdb4f9
-updated: 2017-07-12T13:43:29.152826773+09:00
+hash: b07e1f39655e304f454e283636873542a6a9dfbff317de66c702c29a33dafb66
+updated: 2018-03-08T15:17:40.369449-05:00
 imports:
 - name: github.com/ardielle/ardielle-go
   version: 7d2a39380f7e6beef97bc5462144d6cf902a7ff3
@@ -23,17 +23,22 @@ imports:
   version: 5695738f733662da3e9afc2283bba6f3c879002d
 - name: github.com/pkg/errors
   version: c605e284fe17294bda444b34710735b29d1a9d90
-- name: github.com/Sirupsen/logrus
-  version: 7f976d3a76720c4c27af2ba716b85d2e0a7e38b1
+- name: github.com/sirupsen/logrus
+  version: f4ee69125072b22721efbe639bd0da9c9d19b8cc
 - name: github.com/yahoo/athenz
   version: cc53e4123d013b18cfe3540d98bc3cb73c2adfe2
   subpackages:
   - clients/go/zts
   - libs/go/zmssvctoken
+- name: golang.org/x/crypto
+  version: c7dcf104e3a7a1417abc0230cb0d5240d764159d
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/sys
   version: abf9c25f54453410d0c6668e519582a9e1115027
   subpackages:
   - unix
+  - windows
 - name: gopkg.in/ini.v1
   version: d3de07a94d22b4a0972deb4b96d790c2c0ce8333
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,7 @@ import:
   - ptypes/timestamp
   - ptypes/wrappers
 - package: gopkg.in/ini.v1
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
 - package: github.com/jessevdk/go-flags
 - package: github.com/yahoo/athenz
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,6 +23,9 @@ import:
   subpackages:
   - rdl
 - package: github.com/pkg/errors
+- package: golang.org/x/sys
+  subpackages:
+  - unix
 testImport:
 - package: golang.org/x/sync
   subpackages:

--- a/logger.go
+++ b/logger.go
@@ -3,7 +3,7 @@ package pulsar
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func init() {

--- a/producer.go
+++ b/producer.go
@@ -15,7 +15,7 @@ type Producer struct {
 	*PulsarClient
 }
 
-func (p *Producer) CreateProcuder(
+func (p *Producer) CreateProducer(
 	topic string, producerId, requestId uint64,
 ) (err error) {
 	if err = p.SetLookupTopicConnection(topic, requestId, false); err != nil {

--- a/producer.go
+++ b/producer.go
@@ -3,9 +3,9 @@ package pulsar
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/t2y/go-pulsar/proto/command"
 	pulsar_proto "github.com/t2y/go-pulsar/proto/pb"

--- a/util.go
+++ b/util.go
@@ -1,8 +1,8 @@
 package pulsar
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
+	log "github.com/sirupsen/logrus"
 
 	pulsar_proto "github.com/t2y/go-pulsar/proto/pb"
 )


### PR DESCRIPTION
# Description

The dependencies of the project are out of date. In particular, the Sirupsen/logrus dependency which [made the decision to use all lowercase](https://github.com/sirupsen/logrus/issues/553). In the process of updating all dependencies, I discovered the yahoo/athenz library also changed its API, so I made a fix there.

## What Changed?
* Update Glide dependencies
* Change `Sirupsen/logrus` to `sirupsen/logrus`
* Change `zts.EntityName` to `zts.EntityList` to match the updated Yahoo Athenz API
* Change `Procuder` typo to `Producer`

## How Was This Tested?
* Successfully ran `make`
* Ran example command line commands:

```
$ ./bin/pulsar-client --conf example/default.ini --command produce --topic "persistent://sample/standalone/ns1/my-topic" --messages "Hello Pulsar"
```

```
$ ./bin/pulsar-client --conf example/default.ini --command consume --topic "persistent://sample/standalone/ns1/my-topic" --subscriptionName sub
```

This was tested on Mac OS X with Go 1.10 darwin/amd64.