### PR TITLE
Timeout from Pulsar after 17 minutes

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -240,6 +240,7 @@ func (ac *AsyncConn) decodeFrame(frame *command.Frame) (response *Response) {
 		log.Debug(fmt.Sprintf("%s: received ping", ac.id))
 		ac.conn.SetDeadline(time.Now().Add(ac.config.Timeout))
 		ac.wch <- &Request{Message: &pulsar_proto.CommandPong{}}
+		<-ac.ech
 		log.Debug(fmt.Sprintf("%s: send pong", ac.id))
 		return
 	case pulsar_proto.BaseCommand_CONNECTED:


### PR DESCRIPTION
### Why Make This Change?

- Whenever the `writeLoop()` is run, an error or nil is sent to the `ech` channel. Other pieces of code that write to the `wch` channel end up reading from the `ech` channel in order to consume that message. Because sending Pongs does not, eventually the `ech` channel is filled with messages. Once it is full, it blocks the write loop, causing future Pongs to not be sent and the client eventually gets disconnected from Pulsar due to a timeout.

### What Changed?

- I now consume from the error channel after writing a Pong message. It is possible that there should be more error handling performed here, but I'm unsure how that would work in this code, so instead any potential errors are ignored.